### PR TITLE
Appended rows now get run through the column converter

### DIFF
--- a/demo/append.html
+++ b/demo/append.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>jQuery Bootgrid Demo</title>
+        <link href="css/bootstrap.css" rel="stylesheet"/>
+        <link href="../dist/jquery.bootgrid.css" rel="stylesheet"/>
+        <script src="js/moderniz.2.8.1.js"></script>
+        <style>
+            @-webkit-viewport {
+                width: device-width;
+            }
+            @-moz-viewport {
+                width: device-width;
+            }
+            @-ms-viewport {
+                width: device-width;
+            }
+            @-o-viewport {
+                width: device-width;
+            }
+            @viewport {
+                width: device-width;
+            }
+
+            body {
+                padding-top: 70px;
+            }
+
+            .column .text {
+                color: #f00 !important;
+            }
+            .cell {
+                font-weight: bold;
+            }
+
+        </style>
+    </head>
+    <body>
+        <header id="header" class="navbar navbar-default navbar-fixed-top">
+            <div class="container-fluid">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
+                    <span class="navbar-brand" data-i18n="title">jQuery Bootgrid</span>
+                </div>
+                <nav id="menu" class="navbar-collapse collapse" role="navigation">
+                    <ul class="nav navbar-nav navbar-right">
+                        <li>
+                            <a href="#">Basic Demo</a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
+        </header>
+
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-md-3 visible-md visible-lg">
+                    <div class="affix">
+                        Sub Nav
+                    </div>
+                </div>
+                <div class="col-md-9">
+                    <button id="append" type="button" class="btn btn-default">Append</button>
+                    <button id="clear" type="button" class="btn btn-default">Clear</button>
+                    <!--div class="table-responsive"-->
+                    <table id="grid" class="table table-condensed table-hover table-striped" data-selection="true" data-multi-select="true" data-row-select="true" data-keep-selection="true">
+                        <thead>
+                            <tr>
+                                <th data-name="val" data-column-id="0" data-formatter="number" data-converter="numeric" data-align="left" data-width="40">ID</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr><td>1111</td></tr>
+                            <tr><td>2222</td></tr>
+                            <tr><td>3333</td></tr>
+                            <tr><td>11111</td></tr>
+                        </tbody>
+                    </table>
+                    <!--/div-->
+                </div>
+            </div>
+        </div>
+
+        <footer id="footer">
+            © Copyright 2014-2015, Rafael Staib
+        </footer>
+
+        <script src="../lib/jquery-1.11.1.min.js"></script>
+        <script src="js/bootstrap.js"></script>
+        <script src="../dist/jquery.bootgrid.js"></script>
+        <script src="../dist/jquery.bootgrid.fa.js"></script>
+        <script>
+            $(function() {
+                function init() {
+                    $("#grid").bootgrid({
+                        formatters: {
+                            "link": function(column, row) {
+                                return "<a href=\"#\">" + column.id + ": " + row.id + "</a>";
+                            },
+                            'number': function(column, row) {
+                              try {
+                                return row[column.id].toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+                              } catch (e) {
+                                return row[column.id];
+                              }
+                            },
+                        },
+                        converters: {
+                          numeric: {
+                            // converts from string to numeric
+                            from: function(value) {
+                              console.log('ayy converter from called: ', value);
+                              try {
+                                return parseInt(value);
+                              } catch (e) {
+                                return value
+                              }
+                            },
+                            to: function(value) {
+                              return parseInt(value)
+                            } // converts from numeric to string
+                          },
+                        },
+                        rowCount: [-1, 5, 10, 15],
+                        searchSettings:{
+                            includeHidden: false
+                        }
+                    });
+                }
+
+                init();
+
+                $("#append").on("click", function() {
+                  var getRandomInt = function(min, max) {
+                    return Math.floor(Math.random() * (max - min + 1)) + min;
+                  }
+
+                    $("#grid").bootgrid("append", [
+                        [
+                            getRandomInt(0, 9000).toString(),
+                        ]
+                    ]);
+                });
+
+                $("#clear").on("click", function() {
+                    $("#grid").bootgrid("clear");
+                });
+            });
+        </script>
+    </body>
+</html>

--- a/dist/jquery.bootgrid.js
+++ b/dist/jquery.bootgrid.js
@@ -1366,9 +1366,14 @@ Grid.prototype.append = function(rows)
         var appendedRows = [];
         for (var i = 0; i < rows.length; i++)
         {
-            if (appendRow.call(this, rows[i]))
+            var row = rows[i];
+            for (var j = 0; j < this.columns.length; j++) {
+              var column = this.columns[j];
+              row[column.id] = column.converter.from(row[column.id]);
+            }
+            if (appendRow.call(this, row))
             {
-                appendedRows.push(rows[i]);
+                appendedRows.push(row);
             }
         }
         sortRows.call(this);

--- a/src/public.js
+++ b/src/public.js
@@ -457,9 +457,14 @@ Grid.prototype.append = function(rows)
         var appendedRows = [];
         for (var i = 0; i < rows.length; i++)
         {
-            if (appendRow.call(this, rows[i]))
+            var row = rows[i];
+            for (var j = 0; j < this.columns.length; j++) {
+              var column = this.columns[j];
+              row[column.id] = column.converter.from(row[column.id]);
+            }
+            if (appendRow.call(this, row))
             {
-                appendedRows.push(rows[i]);
+                appendedRows.push(row);
             }
         }
         sortRows.call(this);


### PR DESCRIPTION
This fixes an with appended rows not being interpreted by the column converter. In our case, we would append string numbers (e.x. "100") with the "number" formatter and "numeric" converter. When you would append the row, the value would be put in the rows as a string which was formatted correctly, but it treated the row as a string sort.